### PR TITLE
Fix dependency conflict by moving Stencil to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,11 @@
       ]
     }
   },
-  "dependencies": {
-    "@stencil/core": "^2.13.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.0",
+    "@stencil/core": "^2.13.0",
     "@stencil/postcss": "^2.1.0",
     "@types/jest": "^27.0.3",
     "autoprefixer": "^10.4.12",


### PR DESCRIPTION
## Summary
- move `@stencil/core` from dependencies to devDependencies to avoid conflicts with projects that need `strip-ansi` v7

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68586a196678832e84f712bd95ddaa72